### PR TITLE
Removal of master/slave jargon

### DIFF
--- a/wanted/slaves/admin.py
+++ b/wanted/slaves/admin.py
@@ -7,10 +7,10 @@ from . import models
 # admin.site.register(for x in models.models)
 # [x for x in models])
 
-# for model in apps.get_models():# (get_app('slaves')):
+# for model in apps.get_models():# (get_app('subordinates')):
 #    admin.site.register(model)
 
 # admin.site.register(x for x in models)
-admin.site.register([models.Master, models.Slave, models.Role])
+admin.site.register([models.Main, models.Subordinate, models.Role])
 # admin.site.register(models.Role)
-# admin.site.register(models.Slave)
+# admin.site.register(models.Subordinate)

--- a/wanted/slaves/apps.py
+++ b/wanted/slaves/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
 
 
-class SlavesConfig(AppConfig):
-    name = 'slaves'
+class SubordinatesConfig(AppConfig):
+    name = 'subordinates'

--- a/wanted/slaves/migrations/0001_initial.py
+++ b/wanted/slaves/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='Master',
+            name='Main',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('s_fname', models.CharField(max_length=15)),
@@ -31,11 +31,11 @@ class Migration(migrations.Migration):
                 ('lname', models.CharField(max_length=15)),
                 ('r_descr', models.TextField()),
                 ('join_date', models.DateField(auto_now=True)),
-                ('posted_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='slaves.Master')),
+                ('posted_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='subordinates.Main')),
             ],
         ),
         migrations.CreateModel(
-            name='Slave',
+            name='Subordinate',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('s_fname', models.CharField(max_length=15)),

--- a/wanted/slaves/migrations/0002_auto_20160601_1218.py
+++ b/wanted/slaves/migrations/0002_auto_20160601_1218.py
@@ -8,27 +8,27 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('slaves', '0001_initial'),
+        ('subordinates', '0001_initial'),
     ]
 
     operations = [
         migrations.RenameField(
-            model_name='master',
+            model_name='main',
             old_name='s_descr',
             new_name='m_descr',
         ),
         migrations.RenameField(
-            model_name='master',
+            model_name='main',
             old_name='s_fname',
             new_name='m_fname',
         ),
         migrations.RenameField(
-            model_name='master',
+            model_name='main',
             old_name='s_join_date',
             new_name='m_join_date',
         ),
         migrations.RenameField(
-            model_name='master',
+            model_name='main',
             old_name='s_lname',
             new_name='m_lname',
         ),

--- a/wanted/slaves/urls.py
+++ b/wanted/slaves/urls.py
@@ -3,14 +3,14 @@ from django.conf.urls import url
 from . import views , forms
 
 
-app_name='slaves'
+app_name='subordinates'
 urlpatterns = [
     url(r'^$', views.ShowSl),
-    url(r'^a$', views.ListSlavesView.as_view(), name='list'),
-    url(r'^add$', views.CreateSlave.as_view(),name="add" ),
-    url(r'^sla(?P<pk>\d+)$',  views.DetailSlaveView.as_view(), name='detail'),
-    #url(r'^a(?P<pk>\d+)$',  views.DetailSlaveView.as_view(), name='detail'),
+    url(r'^a$', views.ListSubordinatesView.as_view(), name='list'),
+    url(r'^add$', views.CreateSubordinate.as_view(),name="add" ),
+    url(r'^sla(?P<pk>\d+)$',  views.DetailSubordinateView.as_view(), name='detail'),
+    #url(r'^a(?P<pk>\d+)$',  views.DetailSubordinateView.as_view(), name='detail'),
 
-    # url(r'^sl', 'slaves.urls') ,
+    # url(r'^sl', 'subordinates.urls') ,
     # url(r'^admin/', admin.site.urls),
 ]

--- a/wanted/slaves/views.py
+++ b/wanted/slaves/views.py
@@ -14,9 +14,9 @@ def ShowSl(req):
     return render(req, "main_sl.html")
 
 
-class ListSlavesView(ListView):
-    page_title = "Slaves"
-    model = models.Slave
+class ListSubordinatesView(ListView):
+    page_title = "Subordinates"
+    model = models.Subordinate
 
     # def get_queryset(self):
     #    return super().get_queryset().filter(account__user=self.request.user)
@@ -25,8 +25,8 @@ class ListSlavesView(ListView):
         return super().get_queryset()  # .filter(account__user=self.request.user) .aggregate(sum=Sum('amount'))['sum']
 
 
-class DetailSlaveView(DetailView):
-    model = models.Slave
+class DetailSubordinateView(DetailView):
+    model = models.Subordinate
 
     def get_fname(self):
         return super().get_object().fname
@@ -34,15 +34,15 @@ class DetailSlaveView(DetailView):
     page_title = "דגדגדגד"
 
 
-class CreateSlave(CreateView):
-    model = models.Slave
-    page_title = "create slave"
+class CreateSubordinate(CreateView):
+    model = models.Subordinate
+    page_title = "create subordinate"
     fields = ['fname', 'lname', 'descr', 'cv']
-    success_url = reverse_lazy('slaves:list')
+    success_url = reverse_lazy('subordinates:list')
 
-#    form_class = forms.FormAddSlaveView
+#    form_class = forms.FormAddSubordinateView
 #    class Meta:
-#        model = models.Slave
+#        model = models.Subordinate
 #       fields = '__all__'
 
 # fields = '__all__'

--- a/wanted/wanted/settings.py
+++ b/wanted/wanted/settings.py
@@ -36,7 +36,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'slaves',
+    'subordinates',
 
     'django_extensions',
     'bootstrap3',

--- a/wanted/wanted/urls.py
+++ b/wanted/wanted/urls.py
@@ -23,7 +23,7 @@ from . import views
 
 urlpatterns = [
     url(r'^$',views.index) ,
-    url(r'^sl/', include('slaves.urls')) ,
+    url(r'^sl/', include('subordinates.urls')) ,
     url(r'^admin/', admin.site.urls),
 ]
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.